### PR TITLE
Handle REST GET responses with no body

### DIFF
--- a/generic-common/src/test/java/fi/vm/sade/generic/rest/CachingRestClientTest.java
+++ b/generic-common/src/test/java/fi/vm/sade/generic/rest/CachingRestClientTest.java
@@ -277,4 +277,10 @@ public class CachingRestClientTest extends RestWithCasTestSupport {
         Assert.assertNotSame(orgTicket, TestParams.prevRequestTicketHeaders.get(0));
     }
 
+    @Test(expected = CachingRestClient.HttpException.class)
+    public void testResourceWithoutContentWillNotFail() throws IOException {
+        initClientAuthentication("test");
+        Assert.assertNull(get("/httptest/testResourceNoContent"));
+    }
+
 }

--- a/generic-common/src/test/java/fi/vm/sade/generic/rest/HttpTestResource.java
+++ b/generic-common/src/test/java/fi/vm/sade/generic/rest/HttpTestResource.java
@@ -138,6 +138,13 @@ public class HttpTestResource {
         return Response.status(Response.Status.UNAUTHORIZED).build();
     }
 
+    @Path("/testResourceNoContent")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response testResourceNoContent(@Context HttpServletRequest request) throws URISyntaxException {
+        return Response.status(Response.Status.NOT_MODIFIED).build();
+    }
+
     @Path("/testMethod")
     @GET
     public Response testMethod(@Context HttpServletRequest request) {


### PR DESCRIPTION
CachingRestClient throws NullPointerException if response to GET request has no body.
